### PR TITLE
SITE-797 | Modifiy ns-828, ns-829 for zh wikis (模块 => Module, 模块讨论 => Module talk)

### DIFF
--- a/Scribunto.namespaces.php
+++ b/Scribunto.namespaces.php
@@ -8,6 +8,8 @@
 
 $namespaceNames = [];
 
+$namespaceAliases = [];
+
 $namespaceNames['en'] = [
 	828 => 'Module',
 	829 => 'Module_talk',
@@ -508,8 +510,8 @@ $namespaceNames['yue'] = [
 ];
 
 $namespaceNames['zh'] = [
-	828 => '模块',
-	829 => '模块讨论',
+	828 => 'Module',
+	829 => 'Module_talk',
 ];
 
 $namespaceNames['zh-hans'] = [
@@ -517,7 +519,25 @@ $namespaceNames['zh-hans'] = [
 	829 => '模块讨论',
 ];
 
+$namespaceAliases['zh-hans'] = [
+	'模块' => 828,
+	'模组' => 828,
+	'模块对话' => 829,
+	'模块讨论' => 829,
+	'模组对话' => 829,
+	'模组讨论' => 829,
+];
+
 $namespaceNames['zh-hant'] = [
 	828 => '模組',
 	829 => '模組討論',
+];
+
+$namespaceAliases['zh-hant'] = [
+	'模組' => 828,
+	'模塊' => 828,
+	'模組對話' => 829,
+	'模組討論' => 829,
+	'模塊對話' => 829,
+	'模塊討論' => 829,
 ];


### PR DESCRIPTION
https://fandom.atlassian.net/browse/SITE-797

----

https://phabricator.wikimedia.org/T286105
https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Scribunto/+/702950

----

Update zh/zh-* namespace names and adding namespace aliases in Scribunto

zh namespace names should be in en by default and having zh variant names as namespace aliases.

This commit will change the zh namespace name to English (which it should be) by default and keep the old name as aliases with other aliases added to language variants.
This commit is a re-patch/solution for https://gerrit.wikimedia.org/r/c/mediawiki/extensions/Scribunto/+/606768
This commit will fix https://phabricator.wikimedia.org/T165593 in the extension instead of only fix in WMF wikis' config files

Bug: T165593
Bug: T286291
Bug: T286105
Related: I9b40319d374143668a2666b42f59a3799d041afc
Change-Id: Ib083a8ff042daa9bdd30d6a1e8c34f85b500fc12