### PR TITLE
IW-3384 | Add support for global Lua modules

### DIFF
--- a/includes/engines/LuaCommon/LuaEngine.php
+++ b/includes/engines/LuaCommon/LuaEngine.php
@@ -1,5 +1,6 @@
 <?php
 
+use Fandom\GlobalLuaModules\GlobalLuaModuleService;
 use MediaWiki\MediaWikiServices;
 use Wikimedia\ScopedCallback;
 
@@ -565,12 +566,23 @@ abstract class Scribunto_LuaEngine extends ScribuntoEngineBase {
 			return [ $init ];
 		}
 
-		$title = Title::newFromText( $name );
-		if ( !$title || !$title->hasContentModel( CONTENT_MODEL_SCRIBUNTO ) ) {
-			return [];
-		}
+		// Fandom change begin - add support for global Lua modules loaded from a central wiki (IW-3384)
+		if ( class_exists( GlobalLuaModuleService::class ) && GlobalLuaModuleService::isGlobalLuaModule( $name ) ) {
+			$module =
+				MediaWikiServices::getInstance()
+					->getService( GlobalLuaModuleService::class )
+					->getGlobalModule( $this, $name );
+		} else {
+			// local module - fallback to default behavior
+			$title = Title::newFromText( $name );
+			if ( !$title || !$title->hasContentModel( CONTENT_MODEL_SCRIBUNTO ) ) {
+				return [];
+			}
 
-		$module = $this->fetchModuleFromParser( $title );
+			$module = $this->fetchModuleFromParser( $title );
+		}
+		// end Fandom change
+
 		if ( $module ) {
 			// @phan-suppress-next-line PhanUndeclaredMethod
 			return [ $module->getInitChunk() ];


### PR DESCRIPTION
### Description
Add support for global Lua modules in UCP Scribunto, as done before for app in
https://github.com/Wikia/app/pull/4550. Unfortunately Scribunto doesn't offer an
extension point here, so the relevant functionality has to be inlined.

The actual business logic of fetching the content of global modules is handled
by the UCP GlobalLuaModules extension.

### Who might be interested?
@Wikia/cats @mszabo-wikia 